### PR TITLE
Remove Travis build for Ubuntu 14.04 (trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     matrix:
-        - DIST=trusty
         - DIST=xenial
 
 install: beaver install


### PR DESCRIPTION
Supporting trusty just means we wind up doubling the number of test builds to no real purpose, so we might as well drop it.