### PR TITLE
Fix indentation in deb package description

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -4,9 +4,9 @@ OPTS = dict(
     name = VAR.fullname,
     description = '''\
 Lightweight, portable deep learning library
- This package provides the core library exposing the MXNet C API.
- .
- It has been built with OpenCV and OpenMP support disabled.
+This package provides the core library exposing the MXNet C API.
+
+It has been built with OpenCV and OpenMP support disabled.
 ''',
     url = 'https://github.com/dmlc/mxnet',
     maintainer = 'Sociomantic Tsunami <tsunami@sociomantic.com>',


### PR DESCRIPTION
The preceding commit 6042c72a7f5e38ec9df1b8a41cee2753f0df45bf manually indented the body of the package description.  This is not necessary, as commands like `apt show` will handle this by themselves.