### PR TITLE
Include copyright notice, contributors, and license in the deb package

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -18,7 +18,9 @@ It has been built with OpenCV and OpenMP support disabled.
     depends = ['libc6', 'libstdc++6', 'libopenblas-base'],
 )
 
+doc_install_dir = '/usr/share/doc/' + VAR.fullname + '/'
+
 ARGS = FUN.mapfiles('./lib', '/usr/lib', libs, append_suffix=False) + [
-    'LICENSE=/usr/share/doc/' + VAR.fullname + '/copyright',
-    'README.md=/usr/share/doc/' + VAR.fullname + '/',
+    'LICENSE=' + doc_install_dir + 'copyright',
+    'README.md=' + doc_install_dir,
 ]

--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -21,6 +21,8 @@ It has been built with OpenCV and OpenMP support disabled.
 doc_install_dir = '/usr/share/doc/' + VAR.fullname + '/'
 
 ARGS = FUN.mapfiles('./lib', '/usr/lib', libs, append_suffix=False) + [
-    'LICENSE=' + doc_install_dir + 'copyright',
+    'NOTICE=' + doc_install_dir + 'copyright',
+    'LICENSE=' + doc_install_dir,
+    'CONTRIBUTORS.md=' + doc_install_dir,
     'README.md=' + doc_install_dir,
 ]


### PR DESCRIPTION
MXNet includes a separate `NOTICE` file for its copyright declaration, together with the `LICENSE` file containing the Apache License v2.0. This patch updates the deb package definition to make sure that both are included in `/usr/share/doc/libmxnet/`.

Note that in principle the `copyright` file should have a fairly strict format [1], but this is left for a future package update, since there is no strong need at present for this file to be machine-readable.

[1] https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/