### PR TITLE
Update makd from v1.9.1 to v2.1.3

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -1,6 +1,6 @@
 libs = [VAR.shortname + '.a', VAR.shortname + '.so']
 
-OPTS = dict(
+OPTS.update(
     name = VAR.fullname,
     description = '''\
 Lightweight, portable deep learning library
@@ -20,9 +20,10 @@ It has been built with OpenCV and OpenMP support disabled.
 
 doc_install_dir = '/usr/share/doc/' + VAR.fullname + '/'
 
-ARGS = FUN.mapfiles('./lib', '/usr/lib', libs, append_suffix=False) + [
+ARGS.extend(FUN.mapfiles('./lib', '/usr/lib', libs, append_suffix=False))
+ARGS.extend([
     'NOTICE=' + doc_install_dir + 'copyright',
     'LICENSE=' + doc_install_dir,
     'CONTRIBUTORS.md=' + doc_install_dir,
     'README.md=' + doc_install_dir,
-]
+])


### PR DESCRIPTION
This new major version update changes the default integration test dir, and includes some breaking changes to how package creation is managed.

The changes required to migrate are fairly straightforward: the deb package definition now uses `OPTS.update` and `ARGS.extend` instead of assigning these variables directly.

The v2.1.3 patch release also includes a fix to deb package versioning which should ensure that pre-releases (`-alpha.1` etc.) have a lower install priority than stable releases.

* makd v1.9.1(8711da2)...v2.1.3(a3b4da2) (37 commits)
  > Merge tag v2.0.4 into v2.1.x v2.0.4
  > Merge tag v1.11.2 into v2.1.x v1.11.2
  > Merge tag v1.11.1 into v2.1.x v1.11.1
  > Merge tag v2.0.3 into v2.1.x v2.0.3
  > Merge tag v1.11.0 into v2.x.x Features --------
  (...)