### PR TITLE
Update package description and vendor information

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -3,14 +3,20 @@ libs = [VAR.shortname + '.a', VAR.shortname + '.so']
 OPTS.update(
     name = VAR.fullname,
     description = '''\
-Lightweight, portable deep learning library
-This package provides the core library exposing the MXNet C API.
+Apache MXNet (incubating) is a deep learning framework designed for
+both efficiency and flexibility.  It allows you to mix symbolic and
+imperative programming to maximize efficiency and productivity.  At
+its core, MXNet contains a dynamic dependency scheduler that
+automatically parallelizes both symbolic and imperative operations
+on the fly.  A graph optimization layer on top of that makes symbolic
+execution fast and memory efficient.  MXNet is portable and lightweight,
+scaling effectively to multiple GPUs and multiple machines.
 
-It has been built with OpenCV and OpenMP support disabled.
+This package has been built with OpenCV and OpenMP support disabled.
 ''',
     url = 'https://github.com/dmlc/mxnet',
     maintainer = 'Sociomantic Tsunami <tsunami@sociomantic.com>',
-    vendor = 'Distributed (Deep) Machine Learning Community',
+    vendor = 'Apache Software Foundation',
     license = 'Apache License, Version 2.0',
     category = 'libs',
     provides = VAR.shortname,


### PR DESCRIPTION
MXNet is now being incubated by the Apache Software Foundation, so the package vendor information needs to be updated accordingly.  The package description has similarly been updated using the opening paragraph of the MXNet README.