### PR TITLE
Update beaver from v0.1.2 to v0.3.2

### DIFF
--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -1,3 +1,0 @@
-FROM sociomantictsunami/base:xenial-v2
-COPY pkg/docker/ /docker-tmp
-RUN /docker-tmp/build && rm -fr /docker-tmp

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,3 +1,3 @@
-FROM sociomantictsunami/base:trusty-v2
+FROM sociomantictsunami/base:v3
 COPY pkg/docker/ /docker-tmp
 RUN /docker-tmp/build && rm -fr /docker-tmp


### PR DESCRIPTION
Despite jumping 2 minor versions, this update should be a no-op given the beaver setup that we use.

* beaver v0.1.2(f60fd6c)...v0.3.2(82f8c8f) (37 commits)
  > Fix spelling of BEAVER_DOCKER_IMG
  > bintray: Improve error message when -d is invalid
  > bintray: Fix typo in error message
  > codecov: Add prefix to all sent flags
  > codecov: Properly sanitize sent flags
  (...)