### PR TITLE
Use sociomantic-tsunami GitHub URL in package description

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -14,7 +14,7 @@ scaling effectively to multiple GPUs and multiple machines.
 
 This package has been built with OpenCV and OpenMP support disabled.
 ''',
-    url = 'https://github.com/dmlc/mxnet',
+    url = 'https://github.com/sociomantic-tsunami/mxnet/',
     maintainer = 'Sociomantic Tsunami <tsunami@sociomantic.com>',
     vendor = 'Apache Software Foundation',
     license = 'Apache License, Version 2.0',


### PR DESCRIPTION
This replaces the outdated link to upstream GitHub.  Upstream is now https://github.com/apache/incubator-mxnet; however, the tsunami repo provides the exact source used to build the package.  This seems a reasonable interpretation of the Debian policy:
https://www.debian.org/doc/debian-policy/#homepage

... given its stress that the package URL should preferably be the `site from which the original source can be obtained`.