### PR TITLE
Use OpenMP when building libmxnet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 install: beaver install
 
 script:
-    - beaver make USE_BLAS=openblas USE_OPENCV=0 USE_OPENMP=0
+    - beaver make USE_BLAS=openblas USE_OPENCV=0
     - beaver make -f makd/Makd.mak F=production pkg
 
 deploy:


### PR DESCRIPTION
This should allow us to use multithreading MXNet engines in addition to the single-threaded `NaiveEngine`.