### PR TITLE
Use FUN.autodepends to determine libmxnet package dependencies

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -1,4 +1,7 @@
-libs = [VAR.shortname + '.a', VAR.shortname + '.so']
+from os import listdir
+
+libdir = './lib'
+libs = listdir(libdir)
 
 OPTS.update(
     name = VAR.fullname,
@@ -26,7 +29,7 @@ This package has been built with OpenCV support disabled.
 
 doc_install_dir = '/usr/share/doc/' + VAR.fullname + '/'
 
-ARGS.extend(FUN.mapfiles('./lib', '/usr/lib', libs, append_suffix=False))
+ARGS.extend(FUN.mapfiles(libdir, '/usr/lib', libs, append_suffix=False))
 ARGS.extend([
     'NOTICE=' + doc_install_dir + 'copyright',
     'LICENSE=' + doc_install_dir,

--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -2,6 +2,7 @@ from os import listdir
 
 libdir = './lib'
 libs = listdir(libdir)
+dynamic_libs = [l for l in libs if l.endswith('.so')]
 
 OPTS.update(
     name = VAR.fullname,
@@ -24,7 +25,7 @@ This package has been built with OpenCV support disabled.
     category = 'libs',
     provides = VAR.shortname,
     conflicts = VAR.shortname,
-    depends = ['libc6', 'libstdc++6', 'libopenblas-base'],
+    depends = FUN.autodeps(dynamic_libs, path=libdir),
 )
 
 doc_install_dir = '/usr/share/doc/' + VAR.fullname + '/'


### PR DESCRIPTION
This should be more robust than the previous hardcoded dependencies.