### PR TITLE
Add single-line synopsis to package description field

### DIFF
--- a/pkg/libmxnet.pkg
+++ b/pkg/libmxnet.pkg
@@ -6,7 +6,7 @@ dynamic_libs = [l for l in libs if l.endswith('.so')]
 
 OPTS.update(
     name = VAR.fullname,
-    description = '''\
+    description = '''efficient and flexible deep learning framework
 Apache MXNet (incubating) is a deep learning framework designed for
 both efficiency and flexibility.  It allows you to mix symbolic and
 imperative programming to maximize efficiency and productivity.  At


### PR DESCRIPTION
Debian policy states that the package description field should include a single-line synopsis and an extended description:
https://www.debian.org/doc/debian-policy/#the-description-of-a-package