### PR TITLE
Ensure that `F` environment variable gets passed to package build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install: beaver install
 
 script:
     - beaver make USE_BLAS=openblas USE_OPENCV=0
-    - beaver run ./build-tsunami-package
+    - BEAVER_DOCKER_VARS="F" beaver run ./build-tsunami-package
 
 deploy:
     provider: script


### PR DESCRIPTION
Since we're using `beaver run` instead of `beaver make`, `F` will not be passed into the environment automatically, so we need to explicitly say which `BEAVER_DOCKER_VARS` should be used.

Note that `F` makes no practical difference to the result of the build for the time being, but we could easily change that in future (e.g. by making the settings for the MXNet library build depend on it), so it's good to ensure that it propagates correctly now, rather than having it bite us later.