### PR TITLE
Disable F16C instruction set when building on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 install: beaver install
 
 script:
-    - beaver make USE_BLAS=openblas USE_OPENCV=0
+    - beaver make USE_BLAS=openblas USE_OPENCV=0 USE_F16C=0
     - BEAVER_DOCKER_VARS="F" beaver run ./build-tsunami-package
 
 deploy:


### PR DESCRIPTION
This change configures the Travis build without using the F16C
instruction set. Though this instruction set should result in better
performance it reduces portability. CPUs may not support the instruction
set. The used `Makefile` detects whether the CPU performing the build
supports F16C. On Travis the build may be executed on a machine
supporting F16C resulting in libraries that won't work on non-supported
CPUs. Here, we explicitly disable the use of the F16C instruction set
when building on Travis to improve portability of the built libraries.