### PR TITLE
Add copyright notice to the tsunami-package build and upload scripts

### DIFF
--- a/build-tsunami-package
+++ b/build-tsunami-package
@@ -23,6 +23,8 @@
 #
 ################################################################################
 #
+# Copyright (c) 2018 dunnhumby Germany GmbH
+#
 # Boost Software License - Version 1.0 - August 17th, 2003
 #
 # Permission is hereby granted, free of charge, to any person or organization

--- a/upload-tsunami-package
+++ b/upload-tsunami-package
@@ -18,6 +18,8 @@
 #
 ################################################################################
 #
+# Copyright (c) 2018 dunnhumby Germany GmbH
+#
 # Boost Software License - Version 1.0 - August 17th, 2003
 #
 # Permission is hereby granted, free of charge, to any person or organization


### PR DESCRIPTION
This corrects an oversight when the scripts were originally created.